### PR TITLE
Linked script.js to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Anime App</title>
+    <script src="./assets/js/script.js" defer></script>
 </head>
 <body>
     <header>


### PR DESCRIPTION
Linked script.js in the index.html head area using defer.  This will cause the script to be read after the html is all loaded.  Just like to keep all my script elements in the head for organization purposes.